### PR TITLE
Phase 1.2: Implement MCP /mcp/infer with mock response

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ MISTRAL_API_KEY=...
 ```
 Only set the providers you intend to use.
 
-#### Install dependencies (Linux)
-Use your preferred Python tooling. Example with pip:
+#### Setup (venv + requirements) on Linux/Mac
+Create and activate a virtual environment, then install dependencies from `requirements.txt`:
 ```
-pip install fastapi uvicorn httpx python-dotenv pydantic
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install -r requirements.txt
 ```
 
-#### Run the local MCP server (example)
+#### Run the local MCP server
 Adjust the module path to your actual FastAPI app instance (e.g., `server.main:app`).
 ```
 uvicorn server.main:app --host 127.0.0.1 --port 8000
@@ -116,6 +119,12 @@ curl -s http://127.0.0.1:8000/mcp/infer \
       }'
 ```
 
+#### Run tests
+With the virtual environment activated:
+```
+pytest -q
+```
+
 ### Android App (MCP Client)
 - Use Flutter or Kotlin to build a simple chat UI.
 - Point HTTP requests to `http://127.0.0.1:8000/mcp/infer` on device.
@@ -125,8 +134,13 @@ curl -s http://127.0.0.1:8000/mcp/infer \
 1. Install Termux from a trusted source.
 2. Update packages: `pkg update && pkg upgrade`
 3. Install Python and git: `pkg install python git`
-4. Clone project and install deps: `pip install fastapi uvicorn httpx python-dotenv pydantic`
-5. Export API key(s) securely or use `.env` with restrictive permissions.
+4. Clone project and install deps: `pip install -r requirements.txt`
+5. Copy env template and set keys with restrictive permissions:
+   ```
+   cp .env.example .env
+   chmod 600 .env
+   # edit .env to set OPENAI_API_KEY / ANTHROPIC_API_KEY / MISTRAL_API_KEY
+   ```
 6. Start the server (bind to loopback):
    ```
    uvicorn server.main:app --host 127.0.0.1 --port 8000

--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,7 @@
+from typing import List, Literal
+
 from fastapi import FastAPI
+from pydantic import BaseModel, Field
 
 
 app = FastAPI(title="BrainDock MCP Server", version="0.1.0")
@@ -13,4 +16,45 @@ def read_health() -> dict:
 def read_root() -> dict:
     return {"name": "braindock", "version": "0.1.0"}
 
+
+# ==== MCP models and endpoint (Phase 1.2) ====
+
+class MCPMessage(BaseModel):
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class MCPInput(BaseModel):
+    text: str = Field(..., min_length=1)
+
+
+class MCPState(BaseModel):
+    history: List[MCPMessage] = Field(default_factory=list)
+
+
+class MCPInferRequest(BaseModel):
+    session_id: str = Field(..., min_length=1)
+    mcp_input: MCPInput
+    mcp_state: MCPState
+
+
+class MCPInferResponse(BaseModel):
+    session_id: str
+    mcp_output: str
+    mcp_state: MCPState
+
+
+@app.post("/mcp/infer", response_model=MCPInferResponse)
+def mcp_infer(req: MCPInferRequest) -> MCPInferResponse:
+    user_message = MCPMessage(role="user", content=req.mcp_input.text)
+    # Mock assistant reply for Phase 1.2
+    assistant_reply_text = f"Echo: {req.mcp_input.text}"
+    assistant_message = MCPMessage(role="assistant", content=assistant_reply_text)
+
+    updated_history: List[MCPMessage] = [*req.mcp_state.history, user_message, assistant_message]
+    return MCPInferResponse(
+        session_id=req.session_id,
+        mcp_output=assistant_reply_text,
+        mcp_state=MCPState(history=updated_history),
+    )
 

--- a/tests/test_mcp_infer.py
+++ b/tests/test_mcp_infer.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+
+from server.main import app
+
+
+client = TestClient(app)
+
+
+def test_mcp_infer_echoes_and_updates_history():
+    payload = {
+        "session_id": "user-123",
+        "mcp_input": {"text": "Hello"},
+        "mcp_state": {"history": []},
+    }
+    res = client.post("/mcp/infer", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    assert data["session_id"] == "user-123"
+    assert data["mcp_output"] == "Echo: Hello"
+    history = data["mcp_state"]["history"]
+    assert len(history) == 2
+    assert history[0]["role"] == "user" and history[0]["content"] == "Hello"
+    assert history[1]["role"] == "assistant" and history[1]["content"] == "Echo: Hello"
+
+
+def test_mcp_infer_validation_error_on_empty_text():
+    payload = {
+        "session_id": "user-123",
+        "mcp_input": {"text": ""},
+        "mcp_state": {"history": []},
+    }
+    res = client.post("/mcp/infer", json=payload)
+    assert res.status_code == 422
+
+


### PR DESCRIPTION
Implements Phase 1.2.

- Adds Pydantic models for MCP request/response
- Implements `POST /mcp/infer` with mock echo response
- Updates history in returned `mcp_state`
- Adds tests for echo behavior and validation (empty text)

CI: GitHub Actions runs pytest across Python 3.10–3.13.

Closes #2