### PR TITLE
Phase 1.3: Integrate mock LLM adapter with configurable modes

### DIFF
--- a/.cursor/rules/braindock-tech-assessment.mdc
+++ b/.cursor/rules/braindock-tech-assessment.mdc
@@ -132,11 +132,11 @@ You aim to build an Android system that:
 
 | Phase | Milestone | Done | Deliverable |
 | --- | --- | --- | --- |
-| 1 | Linux MCP server prototype |  | FastAPI + mock OpenAI forwarding |
+| 1 | Linux MCP server prototype | ✅ | FastAPI + mock OpenAI forwarding |
 | 1.1 | FastAPI project skeleton | ✅ | Basic FastAPI server running locally |
 | 1.2 | Implement MCP endpoint | ✅ | `/mcp/infer` endpoint with mock response |
-| 1.3 | Integrate mock OpenAI call |  | Forward request to mock LLM, return response |
-| 1.4 | Unit tests for server logic |  | Tests for request/response, context handling |
+| 1.3 | Integrate mock OpenAI call | ✅ | Forward request to mock LLM, return response |
+| 1.4 | Unit tests for server logic | ✅ | Tests for request/response, context handling |
 | 2 | Android app (MCP client) |  | App UI + HTTP calls to local server |
 | 2.1 | Android app project setup |  | Flutter/Kotlin app skeleton with UI scaffold |
 | 2.2 | HTTP client integration |  | App can send POST to local server |
@@ -157,34 +157,6 @@ You aim to build an Android system that:
 | 5.2 | Monitoring and logging |  | Add request/response logging, error handling |
 | 5.3 | UI/UX polish |  | Improve app interface and usability |
 | 5.4 | Production deployment checklist |  | Final docs, security review, release build |
-
-| Phase | Milestone | Deliverable |
-| --- | --- | --- |
-| 1 | Linux MCP server prototype | FastAPI + mock OpenAI forwarding |
-| 1.1 | FastAPI project skeleton | Basic FastAPI server running locally |
-| 1.2 | Implement MCP endpoint | `/mcp/infer` endpoint with mock response |
-| 1.3 | Integrate mock OpenAI call | Forward request to mock LLM, return response |
-| 1.4 | Unit tests for server logic | Tests for request/response, context handling |
-| 2 | Android app (MCP client) | App UI + HTTP calls to local server |
-| 2.1 | Android app project setup | Flutter/Kotlin app skeleton with UI scaffold |
-| 2.2 | HTTP client integration | App can send POST to local server |
-| 2.3 | UI for chat interaction | Basic chat interface, display responses |
-| 2.4 | Integration test: app ⇄ server | End-to-end test of local communication |
-| 3 | Termux MCP server on Android | Same server running natively on Android |
-| 3.1 | Termux environment setup | Documented steps to run server on Android |
-| 3.2 | Deploy FastAPI on Termux | Server runs and responds on Android device |
-| 3.3 | Android app connects to Termux server | App communicates with local server on device |
-| 3.4 | Performance and resource test | Measure latency, CPU, memory on device |
-| 4 | Session storage & context control | Persistent state handling |
-| 4.1 | In-memory session store | Per-session context in Python dict |
-| 4.2 | Persistent context (JSON/SQLite) | Serialize/restore session state |
-| 4.3 | Session management tests | Verify continuity and isolation of sessions |
-| 4.4 | Context control UI in app | App can view/reset session context |
-| 5 | Production deployment | API key management, monitoring, UI polish |
-| 5.1 | Secure API key management | Store API key securely in Termux |
-| 5.2 | Monitoring and logging | Add request/response logging, error handling |
-| 5.3 | UI/UX polish | Improve app interface and usability |
-| 5.4 | Production deployment checklist | Final docs, security review, release build |
 
 ### ✅ Conclusion
 This is a highly feasible, lightweight, and modular architecture that:

--- a/.cursor/rules/braindock-tech-assessment.mdc
+++ b/.cursor/rules/braindock-tech-assessment.mdc
@@ -130,6 +130,34 @@ You aim to build an Android system that:
 
 ### 🧭 Project Milestones (Phases)
 
+| Phase | Milestone | Done | Deliverable |
+| --- | --- | --- | --- |
+| 1 | Linux MCP server prototype |  | FastAPI + mock OpenAI forwarding |
+| 1.1 | FastAPI project skeleton | ✅ | Basic FastAPI server running locally |
+| 1.2 | Implement MCP endpoint | ✅ | `/mcp/infer` endpoint with mock response |
+| 1.3 | Integrate mock OpenAI call |  | Forward request to mock LLM, return response |
+| 1.4 | Unit tests for server logic |  | Tests for request/response, context handling |
+| 2 | Android app (MCP client) |  | App UI + HTTP calls to local server |
+| 2.1 | Android app project setup |  | Flutter/Kotlin app skeleton with UI scaffold |
+| 2.2 | HTTP client integration |  | App can send POST to local server |
+| 2.3 | UI for chat interaction |  | Basic chat interface, display responses |
+| 2.4 | Integration test: app ⇄ server |  | End-to-end test of local communication |
+| 3 | Termux MCP server on Android |  | Same server running natively on Android |
+| 3.1 | Termux environment setup |  | Documented steps to run server on Android |
+| 3.2 | Deploy FastAPI on Termux |  | Server runs and responds on Android device |
+| 3.3 | Android app connects to Termux server |  | App communicates with local server on device |
+| 3.4 | Performance and resource test |  | Measure latency, CPU, memory on device |
+| 4 | Session storage & context control |  | Persistent state handling |
+| 4.1 | In-memory session store |  | Per-session context in Python dict |
+| 4.2 | Persistent context (JSON/SQLite) |  | Serialize/restore session state |
+| 4.3 | Session management tests |  | Verify continuity and isolation of sessions |
+| 4.4 | Context control UI in app |  | App can view/reset session context |
+| 5 | Production deployment |  | API key management, monitoring, UI polish |
+| 5.1 | Secure API key management |  | Store API key securely in Termux |
+| 5.2 | Monitoring and logging |  | Add request/response logging, error handling |
+| 5.3 | UI/UX polish |  | Improve app interface and usability |
+| 5.4 | Production deployment checklist |  | Final docs, security review, release build |
+
 | Phase | Milestone | Deliverable |
 | --- | --- | --- |
 | 1 | Linux MCP server prototype | FastAPI + mock OpenAI forwarding |

--- a/server/llm/__init__.py
+++ b/server/llm/__init__.py
@@ -1,0 +1,4 @@
+from .base import LLMAdapter
+from .mock import MockLLMAdapter
+
+__all__ = ["LLMAdapter", "MockLLMAdapter"]

--- a/server/llm/base.py
+++ b/server/llm/base.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from pydantic import BaseModel
+
+
+class LLMAdapter(ABC):
+    """Abstract base class for LLM adapters."""
+    
+    @abstractmethod
+    async def infer(self, messages: List[dict], **kwargs) -> str:
+        """
+        Send messages to LLM and return response.
+        
+        Args:
+            messages: List of message dicts with 'role' and 'content'
+            **kwargs: Additional parameters for the LLM call
+            
+        Returns:
+            LLM response as string
+        """
+        pass
+    
+    @abstractmethod
+    def is_available(self) -> bool:
+        """
+        Check if the LLM adapter is available/configured.
+        
+        Returns:
+            True if adapter can be used
+        """
+        pass

--- a/server/llm/mock.py
+++ b/server/llm/mock.py
@@ -1,0 +1,45 @@
+import os
+from typing import List
+
+from .base import LLMAdapter
+
+
+class MockLLMAdapter(LLMAdapter):
+    """Mock LLM adapter for testing and development."""
+    
+    def __init__(self, mode: str = "echo"):
+        """
+        Initialize mock adapter.
+        
+        Args:
+            mode: Response mode - "echo", "template", or "random"
+        """
+        self.mode = mode
+    
+    async def infer(self, messages: List[dict], **kwargs) -> str:
+        """Generate mock response based on mode."""
+        if not messages:
+            return "No messages provided."
+        
+        last_message = messages[-1]["content"]
+        
+        if self.mode == "echo":
+            return f"Echo: {last_message}"
+        elif self.mode == "template":
+            return f"I'm a mock LLM. You said: '{last_message}'. This is a template response."
+        elif self.mode == "random":
+            responses = [
+                "That's an interesting point!",
+                "I understand what you're saying.",
+                "Let me think about that...",
+                "Thanks for sharing that with me.",
+                "I appreciate your input."
+            ]
+            import random
+            return random.choice(responses)
+        else:
+            return f"Mock response to: {last_message}"
+    
+    def is_available(self) -> bool:
+        """Mock adapter is always available."""
+        return True

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,76 @@
+import pytest
+from server.llm import MockLLMAdapter
+
+
+class TestMockLLMAdapter:
+    """Test the mock LLM adapter implementation."""
+    
+    def test_echo_mode(self):
+        """Test echo mode returns input with 'Echo:' prefix."""
+        adapter = MockLLMAdapter(mode="echo")
+        messages = [{"role": "user", "content": "Hello world"}]
+        
+        import asyncio
+        response = asyncio.run(adapter.infer(messages))
+        assert response == "Echo: Hello world"
+    
+    def test_template_mode(self):
+        """Test template mode returns structured response."""
+        adapter = MockLLMAdapter(mode="template")
+        messages = [{"role": "user", "content": "Test message"}]
+        
+        import asyncio
+        response = asyncio.run(adapter.infer(messages))
+        assert "I'm a mock LLM" in response
+        assert "Test message" in response
+    
+    def test_random_mode(self):
+        """Test random mode returns one of predefined responses."""
+        adapter = MockLLMAdapter(mode="random")
+        messages = [{"role": "user", "content": "Anything"}]
+        
+        import asyncio
+        response = asyncio.run(adapter.infer(messages))
+        expected_responses = [
+            "That's an interesting point!",
+            "I understand what you're saying.",
+            "Let me think about that...",
+            "Thanks for sharing that with me.",
+            "I appreciate your input."
+        ]
+        assert response in expected_responses
+    
+    def test_empty_messages(self):
+        """Test handling of empty messages list."""
+        adapter = MockLLMAdapter()
+        
+        import asyncio
+        response = asyncio.run(adapter.infer([]))
+        assert response == "No messages provided."
+    
+    def test_multiple_messages(self):
+        """Test that adapter uses the last message."""
+        adapter = MockLLMAdapter(mode="echo")
+        messages = [
+            {"role": "user", "content": "First message"},
+            {"role": "assistant", "content": "Assistant response"},
+            {"role": "user", "content": "Last message"}
+        ]
+        
+        import asyncio
+        response = asyncio.run(adapter.infer(messages))
+        assert response == "Echo: Last message"
+    
+    def test_is_available(self):
+        """Test that mock adapter is always available."""
+        adapter = MockLLMAdapter()
+        assert adapter.is_available() is True
+    
+    def test_invalid_mode_fallback(self):
+        """Test fallback for invalid mode."""
+        adapter = MockLLMAdapter(mode="invalid_mode")
+        messages = [{"role": "user", "content": "Test"}]
+        
+        import asyncio
+        response = asyncio.run(adapter.infer(messages))
+        assert "Mock response to: Test" in response

--- a/tests/test_mcp_infer.py
+++ b/tests/test_mcp_infer.py
@@ -1,3 +1,4 @@
+import os
 from fastapi.testclient import TestClient
 
 from server.main import app
@@ -7,6 +8,7 @@ client = TestClient(app)
 
 
 def test_mcp_infer_echoes_and_updates_history():
+    """Test that MCP endpoint works with default echo mode."""
     payload = {
         "session_id": "user-123",
         "mcp_input": {"text": "Hello"},
@@ -23,7 +25,60 @@ def test_mcp_infer_echoes_and_updates_history():
     assert history[1]["role"] == "assistant" and history[1]["content"] == "Echo: Hello"
 
 
+def test_mcp_infer_with_template_mode():
+    """Test MCP endpoint with template mode."""
+    # Create a new app instance with template mode
+    from server.main import get_llm_adapter
+    from server.llm import MockLLMAdapter
+    
+    # Temporarily override the adapter
+    original_adapter = app.state.llm_adapter if hasattr(app.state, 'llm_adapter') else None
+    app.state.llm_adapter = MockLLMAdapter(mode="template")
+    
+    try:
+        payload = {
+            "session_id": "user-456",
+            "mcp_input": {"text": "Test message"},
+            "mcp_state": {"history": []},
+        }
+        res = client.post("/mcp/infer", json=payload)
+        assert res.status_code == 200
+        data = res.json()
+        assert "I'm a mock LLM" in data["mcp_output"]
+        assert "Test message" in data["mcp_output"]
+    finally:
+        # Restore original adapter
+        if original_adapter:
+            app.state.llm_adapter = original_adapter
+        elif hasattr(app.state, 'llm_adapter'):
+            delattr(app.state, 'llm_adapter')
+
+
+def test_mcp_infer_with_history():
+    """Test that MCP endpoint properly handles conversation history."""
+    payload = {
+        "session_id": "user-789",
+        "mcp_input": {"text": "Second message"},
+        "mcp_state": {
+            "history": [
+                {"role": "user", "content": "First message"},
+                {"role": "assistant", "content": "Echo: First message"}
+            ]
+        },
+    }
+    res = client.post("/mcp/infer", json=payload)
+    assert res.status_code == 200
+    data = res.json()
+    history = data["mcp_state"]["history"]
+    assert len(history) == 4
+    assert history[0]["role"] == "user" and history[0]["content"] == "First message"
+    assert history[1]["role"] == "assistant" and history[1]["content"] == "Echo: First message"
+    assert history[2]["role"] == "user" and history[2]["content"] == "Second message"
+    assert history[3]["role"] == "assistant" and "Second message" in history[3]["content"]
+
+
 def test_mcp_infer_validation_error_on_empty_text():
+    """Test validation error for empty input text."""
     payload = {
         "session_id": "user-123",
         "mcp_input": {"text": ""},


### PR DESCRIPTION
Implements Phase 1.3.

- Add `LLMAdapter` abstract base class for future LLM providers
- Implement `MockLLMAdapter` with echo/template/random response modes
- Wire adapter into `/mcp/infer` endpoint with async support
- Add comprehensive tests for adapter interface and endpoint integration
- Support `MOCK_LLM_MODE` environment variable for testing different behaviors
- Update tech assessment to mark Phase 1.3 and 1.4 as complete

The mock adapter provides deterministic responses for testing and can be easily replaced with real LLM adapters in future phases.

Closes #3